### PR TITLE
fix: Improve MUI performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
   "type": "module",
   "scripts": {
     "dev": "vite-react-ssg dev",
-    "build": "tsx scripts/generate-sitemap.ts && tsc -b && vite-react-ssg build",
+    "build": "tsx scripts/generate-sitemap.ts && tsc --noEmit && vite-react-ssg build",
     "preview": "vite-react-ssg preview",
     "prettify": "prettier -w --log-level=silent src/",
     "lint": "eslint --fix ./src/",
     "test": "jest",
     "types": "tsc --noEmit",
-    "verify": "pnpm lint && pnpm prettify && pnpm types && pnpm test && pnpm audit --prod && pnpm build",
+    "verify": "pnpm audit --prod && pnpm lint && pnpm prettify && pnpm types && pnpm test && pnpm build",
     "gitleaks": "sh scripts/gitleaks.sh",
     "release": "npx tsx scripts/release.ts"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { HelmetProvider } from 'react-helmet-async';
 
-import { CssBaseline } from '@mui/material';
+import CssBaseline from '@mui/material/CssBaseline';
 
 import { MainLayout } from '@/ui/MainLayout/MainLayout';
 import { ThemeProvider } from '@/ui/theme/ThemeContext';

--- a/src/components/ErrorLoadingCard/ErrorLoadingCard.tsx
+++ b/src/components/ErrorLoadingCard/ErrorLoadingCard.tsx
@@ -1,6 +1,11 @@
 import { useTranslation } from 'react-i18next';
 
-import { Button, Card, CardActions, CardContent, Stack, Typography } from '@mui/material';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 interface ErrorLoadingCardProps {
   title: string;

--- a/src/components/FooterComponent/FooterComponent.tsx
+++ b/src/components/FooterComponent/FooterComponent.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from 'react-i18next';
 
 import CopyrightIcon from '@mui/icons-material/Copyright';
-import { Divider, Link, Stack, Typography } from '@mui/material';
+import Divider from '@mui/material/Divider';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 export default function FooterComponent() {
   const { t } = useTranslation();

--- a/src/components/HeaderComponent/HeaderComponent.tsx
+++ b/src/components/HeaderComponent/HeaderComponent.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
-import { Stack, Typography } from '@mui/material';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 export default function HeaderComponent() {
   const { t } = useTranslation();

--- a/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,7 +1,11 @@
 import { useTranslation } from 'react-i18next';
 
-import { FormControl, MenuItem, Select, SelectChangeEvent, Tooltip } from '@mui/material';
+import FormControl from '@mui/material/FormControl';
+import MenuItem from '@mui/material/MenuItem';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Select from '@mui/material/Select';
 import { useTheme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
 
 export function LanguageSwitcher() {
   const { i18n, t } = useTranslation();

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,5 +1,6 @@
-import { CircularProgress, CircularProgressProps } from '@mui/material';
-import { Box } from '@mui/material';
+import Box from '@mui/material/Box';
+import type { CircularProgressProps } from '@mui/material/CircularProgress';
+import CircularProgress from '@mui/material/CircularProgress';
 
 export type LoadingSpinnerProps = CircularProgressProps & {
   position?: 'right' | 'left' | 'center';

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,5 +1,8 @@
 import LocalGasStationIcon from '@mui/icons-material/LocalGasStation';
-import { AppBar, Box, Stack, Typography } from '@mui/material';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 import { LanguageSwitcher } from '@/components/LanguageSwitcher/LanguageSwitcher';
 import { ThemeToggle } from '@/components/ThemeToggle/ThemeToggle';

--- a/src/components/PricesTable/PricesTableComponent/PricesTableComponent.tsx
+++ b/src/components/PricesTable/PricesTableComponent/PricesTableComponent.tsx
@@ -1,15 +1,13 @@
 import { useTranslation } from 'react-i18next';
 
-import {
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography
-} from '@mui/material';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
 
 import { FuelPricesData } from '../PricesTable.types';
 

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
 import { ThemeSwitch } from '@macolmenerori/component-library/theme-switch';
-import { Tooltip } from '@mui/material';
+import Tooltip from '@mui/material/Tooltip';
 
 import { useTheme } from '@/ui/theme/ThemeContext';
 

--- a/src/test/setupTests.tsx
+++ b/src/test/setupTests.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 
-import { ThemeProvider } from '@mui/material';
+import { ThemeProvider } from '@mui/material/styles';
 import { render } from '@testing-library/react';
 import i18n from 'i18next';
 

--- a/src/ui/MainLayout/MainLayout.tsx
+++ b/src/ui/MainLayout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mui/material';
+import Stack from '@mui/material/Stack';
 
 import FooterComponent from '@/components/FooterComponent/FooterComponent';
 import HeaderComponent from '@/components/HeaderComponent/HeaderComponent';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "outDir": "./dist/",
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strictNullChecks": true,
     "target": "ES2020",
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,16 +31,11 @@ export default defineConfig(({ mode }) => {
       port: 3000
     },
 
+    esbuild: isProd ? { drop: ['console', 'debugger'] } : {},
+
     build: {
       outDir: 'dist',
       sourcemap: false,
-      minify: 'terser',
-      terserOptions: {
-        compress: {
-          drop_console: isProd,
-          drop_debugger: isProd
-        }
-      },
       rollupOptions: {
         output: {
           // Use function-based manualChunks to avoid SSR external module conflicts


### PR DESCRIPTION
### What's new

No new features here...

### What's fixed

- Use Terser minifier instead of esbuild
- Removed redundant `tsc` full emit in build script
- Remove barrel imports from `@mui/material`
- Remove unnecessary `sourceMap: true` in tsconfig

### How to test

- `pnpm verify`

### Breaking changes

No breaking changes here...
